### PR TITLE
Potential fix for code scanning alert no. 52: Type confusion through parameter tampering

### DIFF
--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -427,6 +427,12 @@ app.post('/api/database/users', async (req, res) => {
   try {
     const users = req.body
     
+    if (!Array.isArray(users)) {
+      return res.status(400).json({
+        error: 'Invalid request: users must be an array'
+      })
+    }
+    
     // This would save users to Neon database
     // For now, just return success
     res.json({


### PR DESCRIPTION
Potential fix for [https://github.com/Alot1z/multi-hub-project/security/code-scanning/52](https://github.com/Alot1z/multi-hub-project/security/code-scanning/52)

To fix the problem, we should validate that `users` is an array before using its `length` property and before proceeding with any logic that assumes it is an array. If `users` is not an array, the endpoint should return a 400 Bad Request error with an appropriate message. This change should be made in the `/api/database/users` POST endpoint, specifically before accessing `users.length` on line 434. No new methods or imports are needed; we can use `Array.isArray()` for the type check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
